### PR TITLE
fix merge regression on previous commit concerning modes

### DIFF
--- a/examples/breathe2.js
+++ b/examples/breathe2.js
@@ -1,0 +1,7 @@
+var keyboard = require('../');
+
+keyboard.mode('breathe', {
+        left: {color:'blue',secondary:'red'},
+        midle: {color:'blue', secondary:'red'},
+        right: {color:'blue', secondary:'red'},
+    });

--- a/examples/wave4.js
+++ b/examples/wave4.js
@@ -1,0 +1,7 @@
+var keyboard = require('../');
+
+keyboard.mode('wave', {
+        left: {color:'blue',secondary:'red'},
+        middle: {color:'blue', secondary:'red'},
+        right: {color:'blue', secondary:'red'},
+    }, 2);

--- a/lib/setMode.js
+++ b/lib/setMode.js
@@ -48,15 +48,20 @@ module.exports = function (keyboard, mode, regions, period){
      */
 
     var _regions = ['left', 'middle', 'right'];
+    var Def = null;
     for(var k in _regions) {
+      var _k = parseInt(k) *3;
       if (typeof regions[_regions[k]] !== 'undefined') {
-        var Def = getSettingsForRegion (regions[_regions[k]], _regions[k]);
-        sendData (keyboard, k + 1, Def.primary.color, Def.primary.level, 0);
-        sendData (keyboard, k + 2, Def.secondary.color, Def.secondary.level, 0);
-        sendData (keyboard, k + 3, period, period, period);
+        Def = getSettingsForRegion (regions[_regions[k]], _regions[k]);
+        sendData (keyboard, _k + 1, Def.primary.color, Def.primary.level, 0);
+        sendData (keyboard, _k + 2, Def.secondary.color, Def.secondary.level, 0);
+        sendData (keyboard, _k + 3, period, period, period);
+      } else {
+        sendData (keyboard, _k + 1, 'off', 0, 0);
+        sendData (keyboard, _k + 2, 'off', 0, 0);
+        sendData (keyboard, _k + 3, period, period, period);
       }
     }
-
   }
 
   //Initalize the mode


### PR DESCRIPTION
regions adresses are now properly assigned

I also noticed a bug were wave would stop in that case : 

    keyboard.mode('wave', {
        left: {color:'blue',secondary:'red'},
        right: {color:'blue', secondary:'red'},
    }, 0.1);

It would stop to red color, i have no idea why this is happening. This is still a small bug, not very annoying for most usages.